### PR TITLE
docs: fix dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the Core plugin by adding the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-tauri-plugin-localhost = { git = "https://github.com/aptabase/tauri-plugin-aptabase", branch = "v2" }
+tauri-plugin-aptabase = { git = "https://github.com/aptabase/tauri-plugin-aptabase", branch = "v2" }
 ```
 
 You can install the JavaScript Guest bindings using your preferred JavaScript package manager


### PR DESCRIPTION
Fix typo: "tauri-plugin-localhost" to "tauri-plugin-aptabase"