### PR TITLE
fix: invoke is in primitives now

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "@rollup/plugin-node-resolve": "15.0.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "11.0.0",
-    "@tauri-apps/api": "2.0.0-alpha.8",
+    "@tauri-apps/api": "2.0.0-alpha.11",
     "rollup": "2.78.0",
     "tslib": "2.5.0",
     "typescript": "5.0.2"
   },
   "dependencies": {
-    "@tauri-apps/api": "2.0.0-alpha.8"
+    "@tauri-apps/api": "2.0.0-alpha.11"
   }
 }

--- a/webview-src/index.ts
+++ b/webview-src/index.ts
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api';
+import { invoke } from "@tauri-apps/api/primitives";
 
 type Props = {
   [key: string]: string | number;


### PR DESCRIPTION
Tauri v2 put `invoke` under `primitives` recently. So if you are tracking other plugins with branch `v2` and also keeping Tauri v2 alpha up-to-date, this broke the client side of the plugin.

As it is currently, running this client-side in a Tauri app gives you this error:

```
Uncaught (in promise) TypeError: window.__TAURI_IPC__ is not a function
```

This PR fixes that issue, and I was able to verify the fix locally.

What I'm not sure about is how you will go about publishing it :)

To test locally, I had to dive into my node_modules and build the module since all that's in the repo is source code.
 