### PR TITLE
support android tauri v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0"
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false  }
 time = { version = "0.3", features = ["formatting"]}
 os_info = "3"
 uuid = "1"

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -1,10 +1,4 @@
-# Permissions
-
-## allow-track-event
-
-Enables the track_event command without any pre-configured scope.
-
-## deny-track-event
-
-Denies the track_event command without any pre-configured scope.
-
+| Permission | Description |
+|------|-----|
+|`allow-track-event`|Enables the track_event command without any pre-configured scope.|
+|`deny-track-event`|Denies the track_event command without any pre-configured scope.|

--- a/permissions/schemas/schema.json
+++ b/permissions/schemas/schema.json
@@ -17,7 +17,6 @@
     },
     "set": {
       "description": "A list of permissions sets defined",
-      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/PermissionSet"
@@ -132,12 +131,21 @@
         },
         "scope": {
           "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/Scopes"
             }
           ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
         }
       }
     },
@@ -240,6 +248,46 @@
           "description": "Represents a [`f64`].",
           "type": "number",
           "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
         }
       ]
     },

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -9,6 +9,9 @@ static ENGINE_NAME: &str = "WebKit";
 #[cfg(target_os = "windows")]
 static ENGINE_NAME: &str = "WebView2";
 
+#[cfg(target_os = "android")]
+static ENGINE_NAME: &str = "WebView2";
+
 #[cfg(debug_assertions)]
 static IS_DEBUG: bool = true;
 


### PR DESCRIPTION
Not necessarily recommending to merge this as-is, but these are the changes I needed to do in order to get aptabase working on v2 with Android. 

request feature "rustls-tls" is to avoid the openssl issue when building for android; maybe better option is probably to make openssl optional?

https://discord.com/channels/616186924390023171/1072593987271131217

```
 --- stderr
  thread 'main' panicked at '

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = aarch64-linux-android
  openssl-sys = 0.9.80
```