### PR TITLE
Replace usage of `tauri::async_runtime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ links = "tauri-plugin-aptabase"
 [dependencies]
 tauri = "2.1"
 tokio = "1"
+futures = "0.3"
 serde = "1"
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,7 +75,7 @@ impl AptabaseClient {
     pub(crate) fn start_polling(&self, interval: Duration) {
         let dispatcher = self.dispatcher.clone();
 
-        tauri::async_runtime::spawn(async move {
+        tokio::spawn(async move {
             loop {
                 tokio::time::sleep(interval).await;
                 dispatcher.flush().await;
@@ -141,7 +141,7 @@ impl AptabaseClient {
 
     /// Flushes the event queue, blocking the current thread.
     pub fn flush_blocking(&self) {
-        tauri::async_runtime::block_on(async {
+        futures::executor::block_on(async {
             self.flush().await;
         });
     }


### PR DESCRIPTION
This fixes a panic whenever flush_events_blocking was called from within any Tauri event handler.