### PR TITLE
fix: update dependencies and fix tokio runtime panic

### DIFF
--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,7 +11,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/api": "^2.7.0",
     "@aptabase/tauri": "file:../../"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/api": "^2.7.0",
     "tslib": "^2.8.1"
   }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -75,7 +75,7 @@ impl AptabaseClient {
     pub(crate) fn start_polling(&self, interval: Duration) {
         let dispatcher = self.dispatcher.clone();
 
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             loop {
                 tokio::time::sleep(interval).await;
                 dispatcher.flush().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod config;
 mod dispatcher;
 mod sys;
 
-use std::{panic::PanicInfo, sync::Arc, time::Duration};
+use std::{panic::PanicHookInfo, sync::Arc, time::Duration};
 
 use client::AptabaseClient;
 use config::Config;
@@ -28,9 +28,9 @@ pub struct Builder {
 }
 
 pub type PanicHook =
-    Box<dyn Fn(&AptabaseClient, &PanicInfo<'_>, String) + 'static + Sync + Send>;
+    Box<dyn Fn(&AptabaseClient, &PanicHookInfo<'_>, String) + 'static + Sync + Send>;
 
-fn get_panic_message(info: &PanicInfo) -> String {
+fn get_panic_message(info: &PanicHookInfo) -> String {
     let payload = info.payload();
     if let Some(s) = payload.downcast_ref::<&str>() {
         return s.to_string();


### PR DESCRIPTION
## Summary

- Update all Rust and JavaScript dependencies to latest versions
- **Fix tokio runtime panic** by replacing `tokio::spawn` with `tauri::async_runtime::spawn`
- Fix deprecation: `PanicInfo` → `PanicHookInfo`

## Key Fix

The main fix is in `src/client.rs` where `tokio::spawn` is replaced with `tauri::async_runtime::spawn`. This resolves the panic:

```
thread 'main' panicked at tauri-plugin-aptabase/src/client.rs:78:9:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

Using `tauri::async_runtime::spawn` is the correct approach for Tauri plugins as it properly integrates with Tauri's managed runtime.

## Dependencies Updated

### Rust
- tauri: 2.2.5 → 2.7.0
- tauri-plugin: 2.0.4 → 2.3.1
- tokio: 1.43.0 → 1.47.1
- serde: 1.0.217 → 1.0.219
- serde_json: 1.0.138 → 1.0.142
- reqwest: 0.12.12 → 0.12.22
- time: 0.3.37 → 0.3.41
- os_info: 3.9.2 → 3.12.0
- rand: 0.9.0 → 0.9.2
- log: 0.4.25 → 0.4.27

### JavaScript
- @tauri-apps/api: 2.1.1 → 2.7.0
- Example project dependencies updated

## Testing

- ✅ Rust plugin compiles without errors
- ✅ No more runtime panic on startup

Fixes #22
Fixes #25
Supersedes #26