### PR TITLE
chore: bump all dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,17 @@ exclude = ["/examples", "/webview-dist", "/webview-src", "/node_modules"]
 links = "tauri-plugin-aptabase"
 
 [dependencies]
-tauri = "2.2.5"
-tokio = "1.43.0"
+tauri = "2.10.2"
+tokio = "1.49.0"
 futures = "0.3.31"
-serde = "1.0.217"
-serde_json = "1.0.138"
-reqwest = { version = "0.12.12", features = ["json"] }
-time = { version = "0.3.37", features = ["formatting"] }
-os_info = "3.9.2"
-rand = "0.9.0"
-log = "0.4.25"
+serde = "1.0.228"
+serde_json = "1.0.149"
+reqwest = { version = "0.13.2", features = ["json"] }
+time = { version = "0.3.47", features = ["formatting"] }
+os_info = "3.14.0"
+rand = "0.10.0"
+log = "0.4.29"
 sys-locale = "0.3.2"
 
 [build-dependencies]
-tauri-plugin = { version = "2.0.4", features = ["build"] }
+tauri-plugin = { version = "2.5.3", features = ["build"] }

--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -11,14 +11,14 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/api": "^2.10.1",
     "@aptabase/tauri": "file:../../"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.1",
-    "internal-ip": "^7.0.0",
-    "svelte": "^3.49.0",
-    "vite": "^3.0.2",
-    "@tauri-apps/cli": "^2.1.0"
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "internal-ip": "^9.0.0",
+    "svelte": "^5.50.0",
+    "vite": "^7.3.1",
+    "@tauri-apps/cli": "^2.10.0"
   }
 }

--- a/examples/helloworld/src-tauri/Cargo.toml
+++ b/examples/helloworld/src-tauri/Cargo.toml
@@ -15,10 +15,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "2.0", default-features = false, features = [] }
+tauri-build = { version = "2.5", default-features = false, features = [] }
 
 [dependencies]
-tauri = { version = "2.1", features = [] }
+tauri = { version = "2.10", features = [] }
 tauri-plugin-aptabase = { path = "../../../" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "package.json"
   ],
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^15.3.0",
-    "@rollup/plugin-typescript": "^12.1.1",
+    "@rollup/plugin-node-resolve": "^16.0.3",
+    "@rollup/plugin-typescript": "^12.3.0",
     "@rollup/plugin-terser": "^0.4.4",
-    "rollup": "^4.27.4",
-    "typescript": "^5.7.2"
+    "rollup": "^4.57.1",
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/api": "^2.10.1",
     "tslib": "^2.8.1"
   }
 }

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -1,4 +1,3 @@
-
 ## Permission Table
 
 <table>

--- a/permissions/schemas/schema.json
+++ b/permissions/schemas/schema.json
@@ -49,7 +49,7 @@
           "minimum": 1.0
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -111,7 +111,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri internal convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -297,12 +297,14 @@
         {
           "description": "Enables the track_event command without any pre-configured scope.",
           "type": "string",
-          "const": "allow-track-event"
+          "const": "allow-track-event",
+          "markdownDescription": "Enables the track_event command without any pre-configured scope."
         },
         {
           "description": "Denies the track_event command without any pre-configured scope.",
           "type": "string",
-          "const": "deny-track-event"
+          "const": "deny-track-event",
+          "markdownDescription": "Denies the track_event command without any pre-configured scope."
         }
       ]
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use serde_json::{json, Value};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{


### PR DESCRIPTION
## Summary

Update all Rust and JavaScript dependencies to their latest versions. Keeping dependencies current is critical for security, stability, and compatibility.

## Security Fixes Included

### RUSTSEC-2025-0023 — tokio (memory corruption)
- **Affected:** tokio 1.43.0 (our old version)
- **Fixed in:** >= 1.43.1
- **Impact:** The broadcast channel internally calls `clone()` on stored values requiring only `T: Send` but not `T: Sync`. This is unsound because clone implementations for `!Sync` types can trigger **undefined behavior and memory corruption** when called from multiple threads.
- **Upgrade:** 1.43.0 → 1.49.0

### Tauri use-after-free unsoundness (v2.3.0)
- **Affected:** tauri < 2.3.0 (our old 2.2.5)
- **Impact:** `Manager::unmanage` could result in a use-after-free / dangling pointer when retaining a reference to managed state while calling `unmanage()`. The method has been deprecated and replaced with a safe alternative.
- **Upgrade:** 2.2.5 → 2.10.2

### Tauri security hardening (v2.4.0–v2.10.2)
- **v2.4.0:** Added `build > removeUnusedCommands` to strip unused IPC commands at compile time, reducing attack surface
- **v2.6.0:** Callbacks now register within `window.__TAURI_INTERNALS__.callbacks` instead of directly on `window`, reducing exposure surface
- **v2.7.0:** Fixed isolation pattern creating iframes within iframes on Windows, which could affect the security boundary

### reqwest — TLS security improvement
- **Upgrade:** 0.12.12 → 0.13.2
- reqwest v0.13 **defaults to rustls** instead of native-tls, avoiding the attack surface of C-based TLS libraries (OpenSSL). This is a meaningful security posture improvement.

## All Updates

### Rust (Cargo.toml)
| Package | Old | New |
|---|---|---|
| tauri | 2.2.5 | 2.10.2 |
| tauri-plugin | 2.0.4 | 2.5.3 |
| tokio | 1.43.0 | 1.49.0 |
| serde | 1.0.217 | 1.0.228 |
| serde_json | 1.0.138 | 1.0.149 |
| reqwest | 0.12.12 | 0.13.2 |
| time | 0.3.37 | 0.3.47 |
| os_info | 3.9.2 | 3.14.0 |
| rand | 0.9.0 | 0.10.0 |
| log | 0.4.25 | 0.4.29 |

### JavaScript (package.json)
| Package | Old | New |
|---|---|---|
| @tauri-apps/api | ^2.1.1 | ^2.10.1 |
| @rollup/plugin-node-resolve | ^15.3.0 | ^16.0.3 |
| @rollup/plugin-typescript | ^12.1.1 | ^12.3.0 |
| rollup | ^4.27.4 | ^4.57.1 |
| typescript | ^5.7.2 | ^5.9.3 |

### Example project
All dependencies bumped to latest (tauri, svelte, vite, etc.)

## Code Changes

Minimal code change required by `rand` 0.10.0 API: `use rand::Rng` → `use rand::RngExt` (trait was renamed).

## Testing

- ✅ `cargo check` passes with zero errors
- ✅ All dependency versions verified against crates.io and npm registry