### PR TITLE
Add feature flags for TLS selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio = "1.43.0"
 futures = "0.3.31"
 serde = "1.0.217"
 serde_json = "1.0.138"
-reqwest = { version = "0.12.12", features = ["json"] }
+reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
 time = { version = "0.3.37", features = ["formatting"] }
 os_info = "3.9.2"
 rand = "0.9.0"
@@ -26,3 +26,9 @@ sys-locale = "0.3.2"
 
 [build-dependencies]
 tauri-plugin = { version = "2.0.4", features = ["build"] }
+
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]


### PR DESCRIPTION

## Motivation

The plugin's `reqwest` dependency is declared with default features on:

```toml
reqwest = { version = "0.12.12", features = ["json"] }
```

reqwest's defaults include `default-tls`, which pulls in **native-tls** → **OpenSSL**
on non-Apple/Windows targets. Because Cargo features are additive across the
dependency graph, a consumer cannot opt out of this from their own `Cargo.toml` —
so any app that embeds this plugin is forced to build OpenSSL for every
cross-compiled target (Android, Linux), even when the rest of the app uses rustls.

There's no way today to select a pure-Rust TLS stack for the plugin's HTTP client.

## Change

Expose the TLS backend as passthrough features, forwarding to reqwest:

```toml
reqwest = { version = "0.12.12", default-features = false, features = ["json"] }

[features]
default = ["default-tls"]
default-tls = ["reqwest/default-tls"]
native-tls = ["reqwest/native-tls"]
rustls-tls = ["reqwest/rustls-tls"]
```

Consumers who want rustls can now do:

```toml
tauri-plugin-aptabase = { version = ..., default-features = false, features = ["rustls-tls"] }
```

## Backward compatibility

**No behavior change by default.** `default = ["default-tls"]` re-enables reqwest's
`default-tls` exactly as before, so existing users who don't touch features get the
identical native-tls-backed client. This only *adds* the ability to opt into a
different backend.

Manifest-only change; no code changes. Feature names mirror reqwest's own
(`default-tls` / `native-tls` / `rustls-tls`) for familiarity.

Should cover #28