### PR TITLE
ci: add CI and release workflows (auto-publish to crates.io + npm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: Build & Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libglib2.0-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install JS deps
+        run: npm install
+
+      - name: Build JS
+        run: npm run build
+
+      - name: Check Rust
+        run: cargo check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - run: npm install
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Adds CI and release automation so the plugin auto-publishes to crates.io and npm when a GitHub release is published.

## What's added

### .github/workflows/ci.yml
- Runs `cargo check` and `npm run build` on every push to main and on PRs
- Catches build breakages before they land

### .github/workflows/release.yml
- Triggers on `release: published` (when you publish a GitHub release)
- Publishes to crates.io using `CARGO_REGISTRY_TOKEN` secret
- Publishes to npm using `NPM_TOKEN` secret
- Runs in parallel (two jobs, independent)

## Required secrets

These need to be added in repo Settings > Secrets and variables > Actions:

| Secret | Where to get it |
|---|---|
| `CARGO_REGISTRY_TOKEN` | crates.io > Account Settings > API Tokens (needs publish permission for tauri-plugin-aptabase) |
| `NPM_TOKEN` | npmjs.com > Access Tokens (needs publish permission for @aptabase/tauri) |

@cristipufu — since you own both registry packages, you can generate these tokens and add them as repo secrets. No ownership transfer needed. Or if you'd prefer to add @reatlat as owner on both registries:

- crates.io: `cargo owner -a github:reatlat tauri-plugin-aptabase`
- npm: `npm owner add reatlat @aptabase/tauri`

## How it works after this

1. Merge PRs to main
2. Bump version in Cargo.toml + package.json
3. Push git tag matching the version (e.g. `1.2.0`)
4. Create GitHub release from that tag
5. Both workflows fire automatically — crates.io and npm get the new version